### PR TITLE
- add support for .[], .[1:], .[:2]

### DIFF
--- a/op.go
+++ b/op.go
@@ -81,3 +81,17 @@ func Range(from, to int) OpFunc {
 		return scanner.FindRange(in, 0, from, to)
 	}
 }
+
+// From extracts all elements from the array provided from the given index onward, inclusive
+func From(from int) OpFunc {
+	return func(in []byte) ([]byte, error) {
+		return scanner.FindFrom(in, 0, from)
+	}
+}
+
+// To extracts all elements from the array provided up to the given index, inclusive
+func To(to int) OpFunc {
+	return func(in []byte) ([]byte, error) {
+		return scanner.FindTo(in, 0, to)
+	}
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -47,6 +47,21 @@ func TestParse(t *testing.T) {
 			Op:       ".[1:2]",
 			Expected: `["b","c"]`,
 		},
+		"from": {
+			In:       `["a","b","c","d"]`,
+			Op:       ".[1:]",
+			Expected: `["b","c","d"]`,
+		},
+		"to": {
+			In:       `["a","b","c","d"]`,
+			Op:       ".[:2]",
+			Expected: `["a","b","c"]`,
+		},
+		"all": {
+			In:       `["a","b","c","d"]`,
+			Op:       ".[]",
+			Expected: `["a","b","c","d"]`,
+		},
 		"nested index": {
 			In:       `{"abc":"-","def":["a","b","c"]}`,
 			Op:       ".def.[1]",
@@ -82,3 +97,47 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+//func TestFindIndices(t *testing.T) {
+//	testCases := map[string]struct {
+//		In     string
+//		Expect []string
+//	}{
+//		"simple": {
+//			In:     "[0]",
+//			Expect: []string{"0"},
+//		},
+//		"range": {
+//			In:     "[0:1]",
+//			Expect: []string{"0"},
+//		},
+//		"from": {
+//			In:     "[1:]",
+//			Expect: []string{"0"},
+//		},
+//		"to": {
+//			In:     "[:1]",
+//			Expect: []string{"0"},
+//		},
+//	}
+//	for label, tc := range testCases {
+//		t.Run(label, func(t *testing.T) {
+//			matches := jq.FindIndices(tc.In)
+//			t.Logf("%#v", matches[0])
+//			if len(matches) == 0 {
+//				t.Log("no matches")
+//				t.FailNow()
+//			}
+//			if len(matches[0]) != len(tc.Expect) {
+//				t.Log("count mismatch")
+//				t.FailNow()
+//			}
+//			for k, v := range tc.Expect {
+//				if v != matches[0][k] {
+//					t.Log("expected mismatch")
+//					t.FailNow()
+//				}
+//			}
+//		})
+//	}
+//}

--- a/scanner/find_from.go
+++ b/scanner/find_from.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016 Matt Ho <matt.ho@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+// FindTo finds the elements of an array between the specified indexes; inclusive
+func FindFrom(in []byte, pos, from int) ([]byte, error) {
+	pos, err := skipSpace(in, pos)
+	if err != nil {
+		return nil, err
+	}
+
+	if v := in[pos]; v != '[' {
+		return nil, newError(pos, v)
+	}
+	pos++
+
+	idx := 0
+	itemStart := pos
+
+	for {
+		pos, err = skipSpace(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		if idx == from {
+			itemStart = pos
+		}
+
+		// data
+		pos, err = Any(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		pos, err = skipSpace(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		switch in[pos] {
+		case ',':
+			pos++
+		case ']':
+			if idx < from {
+				return nil, errFromOutOfBounds
+			}
+
+			data := in[itemStart:pos]
+			result := make([]byte, 0, len(data)+2)
+			result = append(result, '[')
+			result = append(result, data...)
+			result = append(result, ']')
+			return result, nil
+		}
+
+		idx++
+	}
+}

--- a/scanner/find_from_test.go
+++ b/scanner/find_from_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016 Matt Ho <matt.ho@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner_test
+
+import (
+	"testing"
+
+	"github.com/savaki/jq/scanner"
+)
+
+func TestFindFrom(t *testing.T) {
+	testCases := map[string]struct {
+		In       string
+		From     int
+		Expected string
+		HasErr   bool
+	}{
+		"all": {
+			In:       `["a","b","c","d","e"]`,
+			From:     0,
+			Expected: `["a","b","c","d","e"]`,
+		},
+		"last": {
+			In:       `["a","b","c","d","e"]`,
+			From:     4,
+			Expected: `["e"]`,
+		},
+		"middle": {
+			In:       `["a","b","c","d","e"]`,
+			From:     2,
+			Expected: `["c","d","e"]`,
+		},
+		"mixed": {
+			In:       `["a",{"hello":"world"},"c","d","e"]`,
+			From:     0,
+			Expected: `["a",{"hello":"world"},"c","d","e"]`,
+		},
+		"out of bounds": {
+			In:     `["a",{"hello":"world"},"c","d","e"]`,
+			From:   20,
+			HasErr: true,
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			data, err := scanner.FindFrom([]byte(tc.In), 0, tc.From)
+			if tc.HasErr {
+				if err == nil {
+					t.FailNow()
+				}
+			} else {
+				if string(data) != tc.Expected {
+					t.FailNow()
+				}
+				if err != nil {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/scanner/find_to.go
+++ b/scanner/find_to.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016 Matt Ho <matt.ho@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+// FindTo finds the elements of an array between the specified indexes; inclusive
+func FindTo(in []byte, pos, to int) ([]byte, error) {
+	pos, err := skipSpace(in, pos)
+	if err != nil {
+		return nil, err
+	}
+
+	if v := in[pos]; v != '[' {
+		return nil, newError(pos, v)
+	}
+	pos++
+
+	idx := 0
+	itemStart := pos
+
+	for {
+		pos, err = skipSpace(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		// data
+		pos, err = Any(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		if idx == to {
+			data := in[itemStart:pos]
+			result := make([]byte, 0, len(data)+2)
+			result = append(result, '[')
+			result = append(result, data...)
+			result = append(result, ']')
+			return result, nil
+		}
+
+		pos, err = skipSpace(in, pos)
+		if err != nil {
+			return nil, err
+		}
+
+		switch in[pos] {
+		case ',':
+			pos++
+		case ']':
+			return nil, errIndexOutOfBounds
+		}
+
+		idx++
+	}
+}

--- a/scanner/find_to_test.go
+++ b/scanner/find_to_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016 Matt Ho <matt.ho@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner_test
+
+import (
+	"testing"
+
+	"github.com/savaki/jq/scanner"
+)
+
+func TestFindTo(t *testing.T) {
+	testCases := map[string]struct {
+		In       string
+		To       int
+		Expected string
+		HasErr   bool
+	}{
+		"first": {
+			In:       `["a","b","c","d","e"]`,
+			To:       0,
+			Expected: `["a"]`,
+		},
+		"second": {
+			In:       `["a","b","c","d","e"]`,
+			To:       1,
+			Expected: `["a","b"]`,
+		},
+		"mixed": {
+			In:       `["a",{"hello":"world"},"c","d","e"]`,
+			To:       1,
+			Expected: `["a",{"hello":"world"}]`,
+		},
+		"negative": {
+			In:     `["a",{"hello":"world"},"c","d","e"]`,
+			To:     -1,
+			HasErr: true,
+		},
+		"out of bounds": {
+			In:     `["a",{"hello":"world"},"c","d","e"]`,
+			To:     20,
+			HasErr: true,
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			data, err := scanner.FindTo([]byte(tc.In), 0, tc.To)
+			if tc.HasErr {
+				if err == nil {
+					t.FailNow()
+				}
+			} else {
+				if string(data) != tc.Expected {
+					t.FailNow()
+				}
+				if err != nil {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/scanner/util.go
+++ b/scanner/util.go
@@ -26,6 +26,7 @@ var (
 	errKeyNotFound      = errors.New("key not found")
 	errIndexOutOfBounds = errors.New("index out of bounds")
 	errToLessThanFrom   = errors.New("to index less than from index")
+	errFromOutOfBounds  = errors.New("from index out of bounds")
 	errUnexpectedValue  = errors.New("unexpected value")
 )
 


### PR DESCRIPTION
This adds support for "all in array", "from index to end of array", and "from start of array to index, inclusive"